### PR TITLE
Improve Python 3 compatibility

### DIFF
--- a/jsonschema2rst/parser.py
+++ b/jsonschema2rst/parser.py
@@ -93,8 +93,8 @@ def _traverse_bfs(node, traverse_func):
         The addition/concatenation of ``traverse_func`` results.
     """
     result = traverse_func(node)
-    leaves = filter(lambda child: child.is_leaf(), node.children)
-    inners = filter(lambda child: not child.is_leaf(), node.children)
+    leaves = [child for child in node.children if child.is_leaf()]
+    inners = [child for child in node.children if not child.is_leaf()]
 
     leaves = _sort_nodes(leaves, node.value)
     inners = _sort_nodes(inners, node.value)


### PR DESCRIPTION
`filter` returns an iterator instead of a list on python 3, so this
replaces it with a list comprehension.

Signed-off-by: Micha Moskovic <michamos@gmail.com>