### PR TITLE
utf-8 encoding for schema file

### DIFF
--- a/jsonschema2rst/parser_runner.py
+++ b/jsonschema2rst/parser_runner.py
@@ -99,7 +99,7 @@ def run_parser(
 
                 file_name = os.path.join(root, name)
 
-                with open(file_name) as schema:
+                with open(file_name, encoding='utf-8') as schema:
                     rst_content = schema2rst(schema, excluded_key)
 
                     output = os.path.join(output_folder, _get_rst_name(name))


### PR DESCRIPTION
Explicitly specify encoding (utf-8) when open schema file.
It is need if non-ASCII strings in json schema file.